### PR TITLE
fixes basic setup instructions for KV v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `vault-backend-migrator` is a tool to export and import (migrate) data across vault clusters.
 
-Right now this tool really only supports the `secret`/`kv` (version 1) backend. Other mount points might work, but many create dynamic secrets behind the scenes or don't support all operations (i.e. LIST).
+Right now this tool really only supports the `secret`/`kv` backend (version 1 in particular, although version 2 works too). Other mount points might work, but many create dynamic secrets behind the scenes or don't support all operations (i.e. LIST).
 
 ### Usage
 
@@ -18,7 +18,7 @@ After pulling the code it's helpful to set a few environment variables. (These m
 
 ```
 export VAULT_ADDR=http://127.0.0.1:8200/
-export VAULT_CACERT=<full filepath to .crt bundle>
+export VAULT_CAPATH=<full filepath to .crt bundle>
 export VAULT_TOKEN=<vault token>
 ```
 
@@ -30,11 +30,17 @@ Then you should be able to run an export command:
 $ ./vault-backend-migrator -export secret/ -file secrets.json
 ```
 
+If you are using the version 2 of the backend and want all the data in there:
+
+```
+$ ./vault-backend-migrator -export secret/data/ -metadata secret/metadata/ -file secrets.json -ver 2
+```
+
 This will create a file called `secrets.json` that has all the keys and paths. (Note: This is literally all the secrets from the generic backend. Don't share this file with anyone! The secret data is **encoded** in base64, but there's no protection over this file.)
 
 ##### Importing
 
-Once you've created an export you are able to reconfigure the vault environment variables (`VAULT_ADDR` and `VAULT_TOKEN` usually) to run an import command.
+Once you've created an export you are able to reconfigure the vault environment variables (`VAULT_ADDR` and `VAULT_TOKEN` usually) to run an import command (remember to specify `-ver 2` in the command line when importing to a version 2 backend).
 
 ```
 $ ./vault-backend-migrator -import secret/ -file secrets.json


### PR DESCRIPTION
fixes basic setup instructions for KV v2:

- VAULT_CAPATH is the actual certificate variable used by vault and the the migrator
- KV v2 was not exporting anything with the documented syntax
- README implied KV v2 was not supported, which is not the case