### PR TITLE
Fix reading secrets when key is both a leaf and a subpath

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -103,6 +103,10 @@ func accumulate(acc *[]string, v vault.Vault, basep string, accump string) {
 		return
 	}
 	for _, k := range res {
+		if !strings.HasSuffix(k, "/") {
+			*acc = append(*acc, path.Join(basep, k))
+			continue
+		}
 		accumulate(acc, v, path.Join(basep, k), path.Join(accump, k))
 	}
 }


### PR DESCRIPTION
A path/key may be both a leaf and a subpath.

e.g. 

```
$ vault list secret/
Keys
----
leafandsubpath
leafandsubpath/

$ vault list secret/leafandsubpath
Keys
----
leaf

$ vault read secret/leafandsubpath
Key             	Value
---             	-----
refresh_interval	768h0m0s
value           	abc

$ vault read secret/leafandsubpath/leaf
Key             	Value
---             	-----
refresh_interval	768h0m0s
value           	cba
```

Output before:
```
{ 
  "data":[ 
    { 
      "path":"secret/leafandsubpath/leaf,
      "pairs":[ 
        { 
          "key":"value",
          "value":"Y2Jh"
        }
      ]
    },
    { 
      "path":"secret/leafandsubpath/leaf",
      "pairs":[ 
        { 
          "key":"value",
          "value":"Y2Jh"
        }
        ]
      }
    ]
}
```

Output after:
```
{ 
  "data":[ 
    { 
      "path":"secret/leafandsubpath,
      "pairs":[ 
        { 
          "key":"value",
          "value":"YWJj"
        }
      ]
    },
    { 
      "path":"secret/leafandsubpath/leaf",
      "pairs":[ 
        { 
          "key":"value",
          "value":"Y2Jh"
        }
        ]
      }
    ]
}
```